### PR TITLE
【修复】定时触发任务线程scheduleThread在扫描xxl_job_info表里的可触发任务列表时，如果“已启用”且触发频率较低（如…

### DIFF
--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
@@ -224,7 +224,7 @@
 		FROM xxl_job_info AS t
 		WHERE t.trigger_status = 1
 			and t.trigger_next_time <![CDATA[ <= ]]> #{maxNextTime}
-		ORDER BY id ASC
+		ORDER BY t.trigger_next_time, id ASC
 		LIMIT #{pagesize}
 	</select>
 


### PR DESCRIPTION
…秒级定时触发）的任务数超过6000个，则id值大的任务可能无法被调度的问题。

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
在JobScheduleHelper中，定时触发任务线程scheduleThread在扫描xxl_job_info表里的可触发任务列表时，如果“已启用”且触发频率较低（如秒级定时触发）的任务数超过预读数preReadCount（默认6000=(200+100)*20）个，则xxl_job_info.id值较大的那些任务可能无法被调度。此PR修复为可以优先以xxl_job_info.trigger_next_time来排序，保证大id的任务也能被公平触发到。

**Other information:**